### PR TITLE
Handle non-lowercase repo names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   docker_compose:
     description: "docker-compose file to build and publish images from"
     required: true
-  repo_token: 
+  repo_token:
     description: "Github Repo token"
     required: false
     default: ''

--- a/src/publish.sh
+++ b/src/publish.sh
@@ -1,22 +1,23 @@
 VERSION="$1"
 OVERRIDE="$2"
 REPO_TOKEN="$3"
+GITHUB_REPOSITORY=$(echo "$GITHUB_REPOSITORY" | awk '{print tolower($0)}')
 
 echo "VERSION=$VERSION"
 echo "OVERRIDE=$OVERRIDE"
 
-docker login ghcr.io -u ${GITHUB_REF} -p ${REPO_TOKEN}
+docker login ghcr.io -u "${GITHUB_REF}" -p "${REPO_TOKEN}"
 
-VERSION=$VERSION docker-compose -f docker-compose.yml -f $OVERRIDE up --no-start --remove-orphans
-IMAGES=$(docker inspect --format='{{.Image}}' $(docker ps -aq))
+VERSION=$VERSION docker-compose -f docker-compose.yml -f "$OVERRIDE" up --no-start --remove-orphans
+IMAGES=$(docker inspect --format='{{.Image}}' "$(docker ps -aq)")
 
 echo "IMAGES: $IMAGES"
 for IMAGE in $IMAGES; do
     echo "IMAGE: $IMAGE"
     
-    NAME=$(basename ${GITHUB_REPOSITORY}).$(docker inspect --format '{{ index .Config.Labels "name" }}' $IMAGE)
+    NAME=$(basename "${GITHUB_REPOSITORY}").$(docker inspect --format '{{ index .Config.Labels "name" }}' "$IMAGE")
     TAG="ghcr.io/${GITHUB_REPOSITORY}/$NAME:$VERSION"
 
-    docker tag $IMAGE $TAG
-    docker push $TAG
+    docker tag "$IMAGE" "$TAG"
+    docker push "$TAG"
 done


### PR DESCRIPTION
Github does not allow for repo names with uppercase letters. Please, see the error message below

<img width="693" alt="Screenshot 2022-10-02 at 21 08 53" src="https://user-images.githubusercontent.com/35563366/193471809-d92a58dc-7994-485a-855a-614183029379.png">
